### PR TITLE
[WIP] Support for search through currency alias

### DIFF
--- a/Community.PowerToys.Run.Plugin.CurrencyConverter/Main.cs
+++ b/Community.PowerToys.Run.Plugin.CurrencyConverter/Main.cs
@@ -165,6 +165,22 @@ namespace Community.PowerToys.Run.Plugin.CurrencyConverter
             double conversionRate = 0;
             try
             {
+                HttpClient Client = new HttpClient();
+                string url = $"https://cdn.jsdelivr.net/npm/@fawazahmed0/currency-api@2024.7.5/v1/currencies.json";
+                var response = Client.GetAsync(url).Result;
+                if (!response.IsSuccessStatusCode)
+                {
+                    throw new Exception("Something went wrong while fetching the currencies list");
+                }
+                var content = response.Content.ReadAsStringAsync().Result;
+                if (string.IsNullOrEmpty(content))
+                {
+                    throw new Exception("Something went wrong while fetching the currencies list");
+                }
+                Dictionary<string, JsonElement> currencies = JsonDocument.Parse(content).RootElement.EnumerateObject().ToDictionary(x => x.Name, x => x.Value);
+                fromCurrency = currencies.FirstOrDefault(x => x.Key.StartsWith(fromCurrency)).Key;
+                toCurrency = currencies.FirstOrDefault(x => x.Key.StartsWith(toCurrency)).Key;
+
                 conversionRate = GetConversionRate(fromCurrency, toCurrency);
             }
             catch (Exception e)


### PR DESCRIPTION
Uses [the currency list](https://cdn.jsdelivr.net/npm/@fawazahmed0/currency-api@2024.7.5/v1/currencies.json) to get all possible currencies and selects the first one that starts with what has already been typed, for both fromcurrency and tocurrency. It currently looks like this:
![image](https://github.com/Advaith3600/PowerToys-Run-Currency-Converter/assets/76819071/7d6548d8-11b2-4e16-a2ad-692bbd5b316c)

A nice addition would be to show the `autocompleted` currency, like this:
![image](https://github.com/Advaith3600/PowerToys-Run-Currency-Converter/assets/76819071/9ff50a2e-7f86-4e2c-bbb0-98a5b05709e1)
However, I do not know how to do that.

I hope this helps, please let me know what can be improved <3