### PR TITLE
feat: Use Cloudflare Pages instead of JSDelivr

### DIFF
--- a/Community.PowerToys.Run.Plugin.CurrencyConverter/Main.cs
+++ b/Community.PowerToys.Run.Plugin.CurrencyConverter/Main.cs
@@ -122,7 +122,7 @@ namespace Community.PowerToys.Run.Plugin.CurrencyConverter
             }
             else
             {
-                string url = $"https://cdn.jsdelivr.net/npm/@fawazahmed0/currency-api@latest/v1/currencies/{fromCurrency}.min.json";
+                string url = $"https://latest.currency-api.pages.dev/v1/currencies/{fromCurrency}.min.json";
                 try
                 {
                     HttpClient Client = new HttpClient();


### PR DESCRIPTION
JSDelivr caches data for 12 hours, which impact data accuracy.

Per [this issue comment](https://github.com/fawazahmed0/exchange-api/issues/96#issuecomment-2057881894), using the Cloudflare Pages endpoint is the way to go