### PR TITLE
Use credentials for proxy

### DIFF
--- a/Community.PowerToys.Run.Plugin.CurrencyConverter/Main.cs
+++ b/Community.PowerToys.Run.Plugin.CurrencyConverter/Main.cs
@@ -22,7 +22,7 @@ namespace Community.PowerToys.Run.Plugin.CurrencyConverter
         private PluginInitContext _context;
         private bool _disposed;
         private readonly Dictionary<string, (JsonElement Rates, DateTime Timestamp)> _conversionCache = new();
-        private readonly HttpClient _httpClient = new();
+        private HttpClient _httpClient;
 
         // Settings
         private bool _showWarningsInGlobal;
@@ -452,6 +452,13 @@ namespace Community.PowerToys.Run.Plugin.CurrencyConverter
                 "CurrencyConverter",
                 AliasFileName);
             EnsureAliasFileExists();
+
+            var handler = new HttpClientHandler
+            {
+                UseDefaultCredentials = true,
+                PreAuthenticate = true
+            };
+            _httpClient = new HttpClient(handler);
         }
 
         private void EnsureAliasFileExists()


### PR DESCRIPTION
When a system proxy is set, the extension uses that proxy but does not authenticate, so fetching conversion fails. This PR sets `UseDefaultCredentials` to make it work.

I have tested that this change works for me (where the proxy auths with negotiate), but **not** if it affects environments without proxy or with proxies that do not need any auth.
