### PR TITLE
docs: fix dead currencies.json link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ If you are getting an error saying the alias file is not found, try closing Powe
 
 ### Crypto and other currencies
 
-This plugin also converters real currencies to crypto currencies and vice versa. Refer [here](https://cdn.jsdelivr.net/gh/fawazahmed0/currency-api@1/latest/currencies.json) for the full list of available conversions. 
+This plugin also converters real currencies to crypto currencies and vice versa. Refer [here](https://cdn.jsdelivr.net/npm/@fawazahmed0/currency-api@latest/v1/currencies.json) for the full list of available conversions. 
 
 Example Usage:
 


### PR DESCRIPTION
Fixes #32.

The link to the full list of available currencies pointed to:

`https://cdn.jsdelivr.net/gh/fawazahmed0/currency-api@1/latest/currencies.json`

which now returns **404** — the currency API moved to the `@fawazahmed0` npm scope. Updated it to the current working URL:

`https://cdn.jsdelivr.net/npm/@fawazahmed0/currency-api@latest/v1/currencies.json`

This is consistent with the migrated `fawazahmed0/exchange-api` endpoint already referenced in the **Conversion API** section, and I verified the new URL returns the currency-list JSON.